### PR TITLE
added zip and zipWith. 

### DIFF
--- a/src/collections.h
+++ b/src/collections.h
@@ -23,15 +23,19 @@ public:
 
     // std::list constructor
     Collection<T>(std::list<T> d) {
+        Data = std::vector<T>(d.size());
+        int index = 0;
         for (auto i : d)
-            Data.push_back(i);       
+            Data[index++] = i;
     }
 
     // std::array constructor
     template<size_t N>
     Collection<T>(std::array<T, N> d) {
+        Data = std::vector<T>(N);
+        int index = 0;
         for (auto i : d)
-            Data.push_back(i);       
+            Data[index++] = i;
     }
 
     // C-style array constructor (requires length)

--- a/src/collections.h
+++ b/src/collections.h
@@ -206,8 +206,9 @@ Collection<T>::zip(Collection<U>... other_list) {
     // TODO: list size checking
     using return_type = std::tuple<U...>;
 
-    std::vector<return_type> list;
-    for (int i = 0, e = std::min({other_list.size()...}); i < e; i++) {
+    int size = std::min({other_list.size()...});
+    std::list<return_type> list;
+    for (int i = 0; i < size; i++) {
         list.emplace_back(std::move(other_list.front())...);
         [](...){} ((other_list.pop_front(), 0)...); 
     }
@@ -223,8 +224,9 @@ Collection<T>::zipWith(Function func, Collection<U>... other_list) {
     // TODO: check that func takes as many arguments as there are lists
     using return_type = typename std::result_of<Function(U...)>::type;
 
-    std::vector<return_type> list;
-    for (int i = 0, e = std::min({other_list.size()...}); i < e; i++) {
+    int size = std::min({other_list.size()...});
+    std::list<return_type> list;
+    for (int i = 0; i < size; i++) {
         list.emplace_back(func(other_list.front()...));
         [](...){} ((other_list.pop_front(), 0)...);
     }

--- a/src/collections.h
+++ b/src/collections.h
@@ -2,8 +2,10 @@
 #ifndef COLLECTIONS_H
 #define COLLECTIONS_H
 
+#include <array>
 #include <vector>
 #include <list>
+#include <iterator>
 #include <functional>
 #include <iostream>
 #include <utility>
@@ -14,13 +16,27 @@ class Collection {
 private:
     std::vector<T> Data;
 public:
+    // std::vector constructor
     Collection<T>(std::vector<T> d) {
         Data = d;
     }
 
+    // std::list constructor
     Collection<T>(std::list<T> d) {
         for (auto i : d)
             Data.push_back(i);       
+    }
+
+    // std::array constructor
+    template<size_t N>
+    Collection<T>(std::array<T, N> d) {
+        for (auto i : d)
+            Data.push_back(i);       
+    }
+
+    // C-style array constructor (requires length)
+    Collection<T>(T d[], int len) {
+        Data.assign(d, d + len);
     }
 
     Collection<T>

--- a/src/collections.h
+++ b/src/collections.h
@@ -19,7 +19,7 @@ public:
     // std::vector constructor
     Collection<T>(std::vector<T> d) {
         Data = d;
-    }
+    };
 
     // std::list constructor
     Collection<T>(std::list<T> d) {
@@ -27,7 +27,7 @@ public:
         int index = 0;
         for (auto i : d)
             Data[index++] = i;
-    }
+    };
 
     // std::array constructor
     template<size_t N>
@@ -36,12 +36,12 @@ public:
         int index = 0;
         for (auto i : d)
             Data[index++] = i;
-    }
+    };
 
     // C-style array constructor (requires length)
     Collection<T>(T d[], int len) {
         Data.assign(d, d + len);
-    }
+    };
 
     Collection<T>
     filter(std::function<bool(T)> func);

--- a/src/collections.h
+++ b/src/collections.h
@@ -21,7 +21,7 @@ public:
     Collection<T>(std::vector<T> d) {
         Data = d;
     };
-    
+
     // std::list constructor
     Collection<T>(std::list<T> d) {
         Data = std::vector<T>(d.size());
@@ -29,7 +29,7 @@ public:
         for (auto i : d)
             Data[index++] = i;
     };
-    
+
     // std::array constructor
     template<std::size_t SIZE>
     Collection<T>(std::array<T, SIZE> d) {
@@ -49,7 +49,7 @@ public:
 
     std::list<T>
     list();
-    
+
     Collection<T>
     filter(std::function<bool(T)> func);
 

--- a/src/collections.h
+++ b/src/collections.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <functional>
 #include <iostream>
+#include <utility>
 
 
 template<typename T>
@@ -36,6 +37,14 @@ public:
 
     T
     fold(std::function<T(T, T)> func);
+
+    template<typename U>
+    Collection<std::pair<T, U>>
+    zip(Collection<U> other_list);
+
+    template<typename Function, typename U>
+    Collection<typename std::result_of<Function(T, U)>::type>
+    zipWith(Function func, Collection<U> other_list);
 
     template<typename Function, typename U>
     typename std::result_of<Function(U, T)>::type
@@ -115,6 +124,34 @@ Collection<T>::fold(std::function<T(T, T)> func) {
         val = func(val, Data[i]);
 
     return val;
+};
+
+
+template<typename T>
+template<typename U>
+Collection<std::pair<T, U>>
+Collection<T>::zip(Collection<U> other_list) {
+    // TODO: list size checking 
+    using return_type = std::pair<T, U>;
+
+    std::vector<return_type> list(Data.size());
+    for (int i = 0; i < Data.size(); i++)
+        list[i] = std::make_pair(Data[i], other_list[i]);
+    return Collection<return_type>(list);
+};
+
+
+template<typename T>
+template<typename Function, typename U>
+Collection<typename std::result_of<Function(T, U)>::type>
+Collection<T>::zipWith(Function func, Collection<U> other_list) {
+    // TODO: list size checking
+    using return_type = typename std::result_of<Function(T, U)>::type;
+
+    std::vector<return_type> list(Data.size());
+    for (int i = 0; i < Data.size(); i++)
+        list[i] = func(Data[i], other_list[i]);
+    return Collection<return_type>(list);        
 };
 
 

--- a/src/collections.h
+++ b/src/collections.h
@@ -16,11 +16,12 @@ class Collection {
 private:
     std::vector<T> Data;
 public:
+
     // std::vector constructor
     Collection<T>(std::vector<T> d) {
         Data = d;
     };
-
+    
     // std::list constructor
     Collection<T>(std::list<T> d) {
         Data = std::vector<T>(d.size());
@@ -28,11 +29,11 @@ public:
         for (auto i : d)
             Data[index++] = i;
     };
-
+    
     // std::array constructor
-    template<size_t N>
-    Collection<T>(std::array<T, N> d) {
-        Data = std::vector<T>(N);
+    template<std::size_t SIZE>
+    Collection<T>(std::array<T, SIZE> d) {
+        Data = std::vector<T>(SIZE);
         int index = 0;
         for (auto i : d)
             Data[index++] = i;
@@ -43,6 +44,16 @@ public:
         Data.assign(d, d + len);
     };
 
+    std::vector<T>
+    vector();
+
+    std::list<T>
+    list();
+    
+    template<std::size_t SIZE>
+    std::array<T, SIZE> 
+    array();
+    
     Collection<T>
     filter(std::function<bool(T)> func);
 
@@ -86,6 +97,31 @@ public:
     print();
 
 };
+
+
+template<typename T>
+std::vector<T>
+Collection<T>::vector() {
+    return Data;
+};
+
+
+template<typename T>
+std::list<T>
+Collection<T>::list() {
+    return std::list<T>(std::begin(Data), std::end(Data));
+};
+
+
+template<typename T>
+template<std::size_t SIZE>
+std::array<T, SIZE>
+Collection<T>::array() {
+    std::array<T, Data.size()> array;
+    for (int i = 0; i < SIZE; i++)
+        array[i] = Data[i]; 
+    return array;
+}
 
 
 template<typename T>

--- a/src/collections.h
+++ b/src/collections.h
@@ -3,6 +3,7 @@
 #define COLLECTIONS_H
 
 #include <vector>
+#include <list>
 #include <functional>
 #include <iostream>
 #include <utility>
@@ -15,6 +16,11 @@ private:
 public:
     Collection<T>(std::vector<T> d) {
         Data = d;
+    }
+
+    Collection<T>(std::list<T> d) {
+        for (auto i : d)
+            Data.push_back(i);       
     }
 
     Collection<T>

--- a/src/collections.h
+++ b/src/collections.h
@@ -8,7 +8,7 @@
 #include <iterator>
 #include <functional>
 #include <iostream>
-#include <utility>
+#include <tuple>
 
 
 template<typename T>
@@ -72,7 +72,7 @@ public:
     fold(std::function<T(T, T)> func);
 
     template<typename U>
-    Collection<std::pair<T, U>>
+    Collection<std::tuple<T, U>>
     zip(Collection<U> other_list);
 
     template<typename Function, typename U>
@@ -176,14 +176,14 @@ Collection<T>::fold(std::function<T(T, T)> func) {
 
 template<typename T>
 template<typename U>
-Collection<std::pair<T, U>>
+Collection<std::tuple<T, U>>
 Collection<T>::zip(Collection<U> other_list) {
-    // TODO: list size checking 
-    using return_type = std::pair<T, U>;
+    // TODO: list size checking
+    using return_type = std::tuple<T, U>;
 
     std::vector<return_type> list(Data.size());
     for (int i = 0; i < Data.size(); i++)
-        list[i] = std::make_pair(Data[i], other_list[i]);
+        list[i] = std::make_tuple(Data[i], other_list[i]);
     return Collection<return_type>(list);
 };
 
@@ -198,7 +198,7 @@ Collection<T>::zipWith(Function func, Collection<U> other_list) {
     std::vector<return_type> list(Data.size());
     for (int i = 0; i < Data.size(); i++)
         list[i] = func(Data[i], other_list[i]);
-    return Collection<return_type>(list);        
+    return Collection<return_type>(list);
 };
 
 

--- a/src/collections.h
+++ b/src/collections.h
@@ -50,10 +50,6 @@ public:
     std::list<T>
     list();
     
-    template<std::size_t SIZE>
-    std::array<T, SIZE> 
-    array();
-    
     Collection<T>
     filter(std::function<bool(T)> func);
 
@@ -111,17 +107,6 @@ std::list<T>
 Collection<T>::list() {
     return std::list<T>(std::begin(Data), std::end(Data));
 };
-
-
-template<typename T>
-template<std::size_t SIZE>
-std::array<T, SIZE>
-Collection<T>::array() {
-    std::array<T, Data.size()> array;
-    for (int i = 0; i < SIZE; i++)
-        array[i] = Data[i]; 
-    return array;
-}
 
 
 template<typename T>

--- a/src/syntax/sum_1_100.cpp
+++ b/src/syntax/sum_1_100.cpp
@@ -1,0 +1,16 @@
+#include <ostream>
+#include <vector>
+
+#include "../collections.h"
+
+int main() {
+
+    // standard syntax
+    int sum = 0;
+    for (int i = 0; i <= 100; i++)
+        sum += i; 
+
+    // Collection syntax
+    sum = Collection<int>::range(1,101)
+              .fold([](int x, int y) {return x + y;});
+}

--- a/src/syntax/sum_squares_1_100.cpp
+++ b/src/syntax/sum_squares_1_100.cpp
@@ -1,0 +1,20 @@
+#include <ostream>
+#include <vector>
+
+#include "../collections.h"
+
+int main() {
+
+    // standard syntax
+    int sum = 0;
+    std::vector<int> squares = std::vector<int>(100);
+    for (int i = 0; i < 100; i++)
+        squares[i] = (i+1) * (i+1);
+    for (int i : squares)
+        sum += i;
+
+    // Collection syntax
+    sum = Collection<int>::range(1,101)
+              .map([](int x) {return x * x;})
+              .fold([](int x, int y) {return x + y;});
+}

--- a/src/tests/pass_constructors.cpp
+++ b/src/tests/pass_constructors.cpp
@@ -1,0 +1,27 @@
+#include <list>
+#include <array>
+#include <vector>
+#include <iostream>
+#include <cassert>
+
+#include "../collections.h"
+
+
+int main() {
+    auto even = [](int x) { return x % 2 == 0; };
+
+    std::vector<int> int_vector {2, 3, 4, 5};
+    std::list<int> int_list {2, 3, 4, 5};
+    std::array<int, 4> int_array {2, 3, 4, 5};
+    int int_c_array[] {2, 3, 4, 5};
+
+    auto ints = Collection<int>(int_vector);
+    assert(ints[0] == 2);
+    ints = Collection<int>(int_list);
+    assert(ints[1] == 3);
+    ints = Collection<int>(int_array);
+    assert(ints[2] == 4);
+    ints = Collection<int>(int_c_array, 4);
+    assert(ints[3] == 5);
+
+}

--- a/src/tests/pass_transformers.cpp
+++ b/src/tests/pass_transformers.cpp
@@ -1,0 +1,33 @@
+#include <list>
+#include <array>
+#include <vector>
+#include <iostream>
+#include <cassert>
+
+#include "../collections.h"
+
+
+int main() {
+    std::vector<int> int_vector {2, 3, 4, 5};
+    auto ints = Collection<int>(int_vector);
+    int sum = 0;
+
+    std::array<int, 4> int_array {2, 3, 4, 5};
+
+    std::vector<int> vec = ints.vector();
+    assert(vec[0] == 2);
+    assert(vec[3] == 5);
+    assert(vec.size() == 4);
+
+    std::list<int> lst = ints.list();
+    for (auto i : lst)
+        sum += i;
+    assert(sum == 14);
+    assert(lst.size() == 4);
+
+    sum = 0;
+    std::array<int, 4> arr = ints.array<4>();
+    assert(arr[0] == 2);
+    assert(arr[3] == 5);
+    assert(arr.size() == 4);
+}

--- a/src/tests/pass_transformers.cpp
+++ b/src/tests/pass_transformers.cpp
@@ -24,10 +24,4 @@ int main() {
         sum += i;
     assert(sum == 14);
     assert(lst.size() == 4);
-
-    sum = 0;
-    std::array<int, 4> arr = ints.array<4>();
-    assert(arr[0] == 2);
-    assert(arr[3] == 5);
-    assert(arr.size() == 4);
 }

--- a/src/tests/pass_zip.cpp
+++ b/src/tests/pass_zip.cpp
@@ -1,5 +1,5 @@
 #include <vector>
-#include <utility>
+#include <tuple>
 #include <cassert>
 
 #include "../collections.h"
@@ -10,8 +10,8 @@ int main() {
     auto ints1 = Collection<int>(std::vector<int> {1, 2, 3});
 
     auto ints2 = ints.zip(ints1);
-    assert(ints2[0] == std::make_pair(ints[0], ints1[0]));
-    assert(ints2[1] == std::make_pair(ints[1], ints1[1]));
-    assert(ints2[2] == std::make_pair(ints[2], ints1[2]));
+    assert(ints2[0] == std::make_tuple(ints[0], ints1[0]));
+    assert(ints2[1] == std::make_tuple(ints[1], ints1[1]));
+    assert(ints2[2] == std::make_tuple(ints[2], ints1[2]));
     assert(ints2.size() == 3);
 }

--- a/src/tests/pass_zip.cpp
+++ b/src/tests/pass_zip.cpp
@@ -9,7 +9,7 @@ int main() {
     auto ints = Collection<int>(std::vector<int> {1, 2, 3});
     auto ints1 = Collection<int>(std::vector<int> {1, 2, 3});
 
-    auto ints2 = ints.zip(ints1);
+    auto ints2 = Collection<int>::zip(ints, ints1);
     assert(ints2[0] == std::make_tuple(ints[0], ints1[0]));
     assert(ints2[1] == std::make_tuple(ints[1], ints1[1]));
     assert(ints2[2] == std::make_tuple(ints[2], ints1[2]));

--- a/src/tests/pass_zip.cpp
+++ b/src/tests/pass_zip.cpp
@@ -4,14 +4,14 @@
 
 #include "../collections.h"
 
-
 int main() {
     auto ints = Collection<int>(std::vector<int> {1, 2, 3});
     auto ints1 = Collection<int>(std::vector<int> {1, 2, 3});
 
     auto ints2 = Collection<int>::zip(ints, ints1);
+
+    assert(ints2.size() == 3);
     assert(ints2[0] == std::make_tuple(ints[0], ints1[0]));
     assert(ints2[1] == std::make_tuple(ints[1], ints1[1]));
     assert(ints2[2] == std::make_tuple(ints[2], ints1[2]));
-    assert(ints2.size() == 3);
 }

--- a/src/tests/pass_zip.cpp
+++ b/src/tests/pass_zip.cpp
@@ -1,0 +1,17 @@
+#include <vector>
+#include <utility>
+#include <cassert>
+
+#include "../collections.h"
+
+
+int main() {
+    auto ints = Collection<int>(std::vector<int> {1, 2, 3});
+    auto ints1 = Collection<int>(std::vector<int> {1, 2, 3});
+
+    auto ints2 = ints.zip(ints1);
+    assert(ints2[0] == std::make_pair(ints[0], ints1[0]));
+    assert(ints2[1] == std::make_pair(ints[1], ints1[1]));
+    assert(ints2[2] == std::make_pair(ints[2], ints1[2]));
+    assert(ints2.size() == 3);
+}

--- a/src/tests/pass_zipWith.cpp
+++ b/src/tests/pass_zipWith.cpp
@@ -10,7 +10,7 @@ int main() {
 
     auto add = [](int x, int y) { return x + y; };
 
-    auto ints2 = ints.zipWith(add, ints1);
+    auto ints2 = Collection<int>::zipWith(add, ints, ints1);
     assert(ints2[0] == 2);
     assert(ints2[1] == 4);
     assert(ints2[2] == 6);

--- a/src/tests/pass_zipWith.cpp
+++ b/src/tests/pass_zipWith.cpp
@@ -1,0 +1,18 @@
+#include <vector>
+#include <cassert>
+
+#include "../collections.h"
+
+
+int main() {
+    auto ints = Collection<int>(std::vector<int> {1, 2, 3});
+    auto ints1 = Collection<int>(std::vector<int> {1, 2, 3});
+
+    auto add = [](int x, int y) { return x + y; };
+
+    auto ints2 = ints.zipWith(add, ints1);
+    assert(ints2[0] == 2);
+    assert(ints2[1] == 4);
+    assert(ints2[2] == 6);
+    assert(ints2.size() == 3);
+}


### PR DESCRIPTION
zip makes use of std::pair to represent tuples of possibly different objects, which creates a dependency on the <utility> lib.

We should discuss whether we want to use std::pair, the more generalized std::tuple, or write our own implementation.

closes #14 