### PR TITLE
added concatenation function to concatenate arbitrary # of collections

### DIFF
--- a/src/collections.h
+++ b/src/collections.h
@@ -520,7 +520,6 @@ namespace cpp_collections {
     template<typename T>
     void
     concat_helper(std::vector<T>& list, Collection<T>& other_list, int& index) {
-        std::cout << index << std::endl;
         for (int i = 0; i < other_list.size(); i++)
             list[index++] = other_list[i];
     }

--- a/src/collections.h
+++ b/src/collections.h
@@ -246,6 +246,7 @@ namespace cpp_collections {
     // ADVANCED OPERATIONS
     // --------------------------
 
+    // Apply a function to all the elements in the Collection
     template<typename T>
     void
     Collection<T>::each(std::function<void(T)> func) {
@@ -518,19 +519,26 @@ namespace cpp_collections {
 
     template<typename T>
     void
-    concat_helper(std::vector<T>& list, Collection<T>& other_list) {
+    concat_helper(std::vector<T>& list, Collection<T>& other_list, int& index) {
+        std::cout << index << std::endl;
         for (int i = 0; i < other_list.size(); i++)
-            list.push_back(other_list[i]);
+            list[index++] = other_list[i];
     }
     
     // Concatenate an arbitrary number of Collections
     template<typename T, typename ...Collections>
     Collection<T>
     concat(Collection<T>& original, Collections... other_list) {
-        // TODO: Check that all arguments are of type Collection<T>&
-        std::vector<T> list;
-        concat_helper(list, original);
-        int unpack[]{0, (concat_helper(list, other_list), 0)...};
+        // TODO: Check that all arguments are Collections of the same type with
+        // a static_assert. However, note that this check is already being made
+        // implicitly by concat_helper 
+        int size = original.size();
+        int get_size[]{0, (size += other_list.size(), 0)...};
+        std::vector<T> list(size);
+
+        int index = 0;
+        concat_helper(list, original, index);
+        int concatenate[]{0, (concat_helper(list, other_list, index), 0)...};
         return Collection<T>(list);
     }
 

--- a/src/collections.h
+++ b/src/collections.h
@@ -117,6 +117,10 @@ namespace cpp_collections {
         // Apply a function to all the elements in the Collection
         void
         each(std::function<void(T)> func);
+
+        // Return the result of the concatenation of the Collection with other
+        Collection<T>
+        concat(Collection<T>& other);
     
         // Return the elements that pass a predicate function
         Collection<T>
@@ -251,6 +255,18 @@ namespace cpp_collections {
     Collection<T>::each(std::function<void(T)> func) {
         for (auto i : Data)
             func(i);
+    }
+
+    template<typename T>
+    Collection<T>
+    Collection<T>::concat(Collection<T>& other) {
+        std::vector<T> list(Data.size() + other.size());
+        for (int i = 0; i < Data.size() + other.size(); i++)
+            if (i < Data.size())
+                list[i] = Data[i];
+            else
+                list[i] = other[i - Data.size()];
+        return Collection<T>(list);
     }
 
     // Return the elements that pass a predicate function
@@ -518,7 +534,7 @@ namespace cpp_collections {
 
     // Return Collection of numeric types over the range [0, size)
     template<typename T>
-    Collection<T>&
+    Collection<T>
     range(T size) {
         static_assert(std::is_arithmetic<T>::value, 
             "You must pass range arithmetic type parameters");
@@ -526,13 +542,12 @@ namespace cpp_collections {
         std::vector<T> list(size);
         for (int i = 0; i < size; i++)
             list[i] = T(i);
-        static auto x = Collection<T>(list);
-        return x;
+        return Collection<T>(list);
     }
 
     // Return Collection of numeric types over the range [low, high)
     template<typename T>
-    Collection<T>&
+    Collection<T>
     range(T low, T high) {
         static_assert(std::is_arithmetic<T>::value, 
             "You must pass range arithmetic type parameters");
@@ -540,10 +555,8 @@ namespace cpp_collections {
         std::vector<T> list(high-low);
         for (int i = 0; i < high-low; i++)
             list[i] = T(low + i);
-        static auto x = Collection<T>(list);
-        return x;
+        return Collection<T>(list);
     }
-
 
     // Return a Collection of tuples, where each tuple contains the elements of 
     // the zipped lists that occur at the same position

--- a/src/collections.h
+++ b/src/collections.h
@@ -118,10 +118,6 @@ namespace cpp_collections {
         void
         each(std::function<void(T)> func);
 
-        // Return the result of the concatenation of the Collection with other
-        Collection<T>
-        concat(Collection<T>& other);
-    
         // Return the elements that pass a predicate function
         Collection<T>
         filter(std::function<bool(T)> func);
@@ -255,18 +251,6 @@ namespace cpp_collections {
     Collection<T>::each(std::function<void(T)> func) {
         for (auto i : Data)
             func(i);
-    }
-
-    template<typename T>
-    Collection<T>
-    Collection<T>::concat(Collection<T>& other) {
-        std::vector<T> list(Data.size() + other.size());
-        for (int i = 0; i < Data.size() + other.size(); i++)
-            if (i < Data.size())
-                list[i] = Data[i];
-            else
-                list[i] = other[i - Data.size()];
-        return Collection<T>(list);
     }
 
     // Return the elements that pass a predicate function
@@ -531,6 +515,24 @@ namespace cpp_collections {
     // --------------------------
     // NON-MEMBER FUNCTIONS
     // --------------------------
+
+    template<typename T>
+    void
+    concat_helper(std::vector<T>& list, Collection<T>& other_list) {
+        for (int i = 0; i < other_list.size(); i++)
+            list.push_back(other_list[i]);
+    }
+    
+    // Concatenate an arbitrary number of Collections
+    template<typename T, typename ...Collections>
+    Collection<T>
+    concat(Collection<T>& original, Collections... other_list) {
+        // TODO: Check that all arguments are of type Collection<T>&
+        std::vector<T> list;
+        concat_helper(list, original);
+        int unpack[]{0, (concat_helper(list, other_list), 0)...};
+        return Collection<T>(list);
+    }
 
     // Return Collection of numeric types over the range [0, size)
     template<typename T>

--- a/src/tests/fail_concat.cpp
+++ b/src/tests/fail_concat.cpp
@@ -1,0 +1,20 @@
+#include <list>
+#include <array>
+#include <vector>
+#include <iostream>
+#include <cassert>
+
+#include "../collections.h"
+
+using namespace cpp_collections;
+
+int main() {
+
+    Collection<int> a = range(5);
+
+    Collection<char> b = Collection<char>(std::vector<char> {'a','b','c'});
+    
+    auto c = concat(a, b);
+    
+    c.print();
+}

--- a/src/tests/pass_concat.cpp
+++ b/src/tests/pass_concat.cpp
@@ -13,6 +13,12 @@ int main() {
     Collection<int> a = range(5);
 
     Collection<int> b = range(5,11);
+    
+    Collection<int> c = range(11, 21);
 
-    assert(a.concat(b) == range(11));
+    Collection<int> d = concat(a, b, c);
+    
+    d.print();
+
+    assert(d == range(21));
 }

--- a/src/tests/pass_concat.cpp
+++ b/src/tests/pass_concat.cpp
@@ -1,0 +1,18 @@
+#include <list>
+#include <array>
+#include <vector>
+#include <iostream>
+#include <cassert>
+
+#include "../collections.h"
+
+using namespace cpp_collections;
+
+int main() {
+
+    Collection<int> a = range(5);
+
+    Collection<int> b = range(5,11);
+
+    assert(a.concat(b) == range(11));
+}


### PR DESCRIPTION
Edited range to return collections, as opposed to references to collections, to fix an bug observed when calling multiple range functions in sequence