### PR TITLE
Tmap/treduce

### DIFF
--- a/src/benchmarks/bench_map_tmap.cpp
+++ b/src/benchmarks/bench_map_tmap.cpp
@@ -1,0 +1,43 @@
+#include <iostream>
+#include <vector>
+
+#include "../collections.h"
+#include "benchmark.h"
+
+#define size 1000000
+#define trials 50
+
+using namespace cpp_collections;
+
+int main() {
+    // timing map on a vector of size 100,000
+    auto input = [](){ return range(0, size); };
+    auto inc = [](int x) {return x+1;};
+    random_generator rand_gen;
+
+    auto rand_input = [&](){
+        std::vector<int> data(size);
+        for (int i = 0; i < size; i++)
+            data[i] = rand_gen(size);
+        return data;
+    };
+
+    std::cout << "Comparing map & tmap" << std::endl;
+
+
+    bench(input, [&](Collection<int> i){
+        return i.map(inc);
+    }, trials, "map: linear map");
+
+    bench(input, [&](Collection<int> i){
+        return i.tmap(inc, 4);
+    }, trials, "tmap: parallel map");
+
+    bench(rand_input, [&](Collection<int> i){
+        return i.map(inc);
+    }, trials, "map: linear map w/ random data");
+
+    bench(rand_input, [&](Collection<int> i){
+        return i.tmap(inc, 4);
+    }, trials, "tmap: parallel map w/ random data");
+}

--- a/src/benchmarks/bench_pmap_tmap.cpp
+++ b/src/benchmarks/bench_pmap_tmap.cpp
@@ -1,0 +1,43 @@
+#include <iostream>
+#include <vector>
+
+#include "../collections.h"
+#include "benchmark.h"
+
+#define size 1000000
+#define trials 50
+
+using namespace cpp_collections;
+
+int main() {
+    // timing map on a vector of size 100,000
+    auto input = [](){ return range(0, size); };
+    auto inc = [](int x) {return x+1;};
+    random_generator rand_gen;
+
+    auto rand_input = [&](){
+        std::vector<int> data(size);
+        for (int i = 0; i < size; i++)
+            data[i] = rand_gen(size);
+        return data;
+    };
+
+    std::cout << "Comparing pmap & tmap" << std::endl;
+
+
+    bench(input, [&](Collection<int> i){
+        return i.pmap(inc, 4);
+    }, trials, "pmap: parallel map");
+
+    bench(input, [&](Collection<int> i){
+        return i.tmap(inc, 4);
+    }, trials, "tmap: parallel map");
+
+    bench(rand_input, [&](Collection<int> i){
+        return i.pmap(inc, 4);
+    }, trials, "pmap: parallel map w/ random data");
+
+    bench(rand_input, [&](Collection<int> i){
+        return i.tmap(inc, 4);
+    }, trials, "tmap: parallel map w/ random data");
+}

--- a/src/benchmarks/bench_preduce_treduce.cpp
+++ b/src/benchmarks/bench_preduce_treduce.cpp
@@ -1,0 +1,44 @@
+#include <iostream>
+#include <vector>
+
+#include "../collections.h"
+#include "benchmark.h"
+
+#define size 1000000
+#define trials 50
+
+using namespace cpp_collections;
+
+
+int main() {
+    // timing reduce on a vector of size 100,000
+    auto input = [](){ return range(0, size); };
+    auto add = [](int x, int y) {return x+y;};
+    random_generator rand_gen;
+
+    auto rand_input = [&](){
+        std::vector<int> data(size);
+        for (int i = 0; i < size; i++)
+            data[i] = rand_gen(size);
+        return data;
+    };
+
+    std::cout << "Comparing preduce & treduce" << std::endl;
+
+
+    bench(input, [&](Collection<int> i){
+        return i.preduce(add, 4);
+    }, trials, "preduce: parallel reduce");
+
+    bench(input, [&](Collection<int> i){
+        return i.treduce(add, 4);
+    }, trials, "treduce: parallel reduce");
+
+    bench(rand_input, [&](Collection<int> i){
+        return i.preduce(add, 4);
+    }, trials, "preduce: parallel reduce w/ random data");
+
+    bench(rand_input, [&](Collection<int> i){
+        return i.treduce(add, 4);
+    }, trials, "treduce: parallel reduce w/ random data");
+}

--- a/src/benchmarks/bench_reduceLeft_treduce.cpp
+++ b/src/benchmarks/bench_reduceLeft_treduce.cpp
@@ -1,0 +1,44 @@
+#include <iostream>
+#include <vector>
+
+#include "../collections.h"
+#include "benchmark.h"
+
+#define size 1000000
+#define trials 50
+
+using namespace cpp_collections;
+
+
+int main() {
+    // timing reduce on a vector of size 100,000
+    auto input = [](){ return range(0, size); };
+    auto add = [](int x, int y) {return x+y;};
+    random_generator rand_gen;
+
+    auto rand_input = [&](){
+        std::vector<int> data(size);
+        for (int i = 0; i < size; i++)
+            data[i] = rand_gen(size);
+        return data;
+    };
+
+    std::cout << "Comparing reduceLeft & treduce" << std::endl;
+
+
+    bench(input, [&](Collection<int> i){
+        return i.reduceLeft(add);
+    }, trials, "reduceLeft: linear reduceLeft");
+
+    bench(input, [&](Collection<int> i){
+        return i.treduce(add, 4);
+    }, trials, "treduce: parallel reduce");
+
+    bench(rand_input, [&](Collection<int> i){
+        return i.reduceLeft(add);
+    }, trials, "reduceLeft: linear reduceLeft w/ random data");
+
+    bench(rand_input, [&](Collection<int> i){
+        return i.treduce(add, 4);
+    }, trials, "treduce: parallel reduce w/ random data");
+}

--- a/src/tests/pass_constructors.cpp
+++ b/src/tests/pass_constructors.cpp
@@ -25,4 +25,10 @@ int main() {
     ints = Collection<int>(int_c_array, 4);
     assert(ints[3] == 5);
 
+    auto a = Collection<int>();
+    assert(a.size() == 0);
+    auto b = Collection<int>(5);
+    assert(b.size() == 5);
+    assert(b[1] == 0);
+
 }

--- a/src/tests/pass_tmap.cpp
+++ b/src/tests/pass_tmap.cpp
@@ -1,0 +1,18 @@
+#include <vector>
+#include <iostream>
+#include <cassert>
+
+#include "../collections.h"
+
+using namespace cpp_collections;
+
+int main(){
+    Collection<int> ints = range(10);
+
+    auto incr = [](int x) {return x+1;};
+    auto result = ints.tmap(incr, 3);
+
+    result.print();
+
+    assert(result == range(1, 11));
+}

--- a/src/tests/pass_treduce.cpp
+++ b/src/tests/pass_treduce.cpp
@@ -1,0 +1,19 @@
+#include <vector>
+#include <iostream>
+#include <cassert>
+
+#include "../collections.h"
+
+using namespace cpp_collections;
+
+
+int main(){
+    auto ints = range(1,11);
+
+    auto add = [](int x, int y) {return x+y;};
+    int i = ints.treduce(add, 3);
+
+    std::cout << i << std::endl;
+
+    assert(i == 55);
+}


### PR DESCRIPTION
this is dope.

re-wrote the pmap and preduce functions to use standard lib `thread`s. see results of new benchmarks:

tmap does slightly better than the existing pmap

```
running benchmarks matching 'tmap'
==========================
bench_map_tmap: Comparing map & tmap
	6.2049 milliseconds | map: linear map | 50 trials
	5.3801 milliseconds | tmap: parallel map | 50 trials
	8.2372 milliseconds | map: linear map w/ random data | 50 trials
	7.0558 milliseconds | tmap: parallel map w/ random data | 50 trials
bench_pmap_tmap: Comparing pmap & tmap
	4.3043 milliseconds | pmap: parallel map | 50 trials
	4.457 milliseconds | tmap: parallel map | 50 trials
	6.1789 milliseconds | pmap: parallel map w/ random data | 50 trials
	6.166 milliseconds | tmap: parallel map w/ random data | 50 trials
```

treduce appears to totally obliterate preduce

```
running benchmarks matching 'treduce'
==========================
bench_preduce_treduce: Comparing preduce & treduce
	5.093 milliseconds | preduce: parallel reduce | 50 trials
	1.8599 milliseconds | treduce: parallel reduce | 50 trials
	9.8352 milliseconds | preduce: parallel reduce w/ random data | 50 trials
	2.7506 milliseconds | treduce: parallel reduce w/ random data | 50 trials
bench_reduceLeft_treduce: Comparing reduceLeft & treduce
	3.6137 milliseconds | reduceLeft: linear reduceLeft | 50 trials
	1.7219 milliseconds | treduce: parallel reduce | 50 trials
	4.4911 milliseconds | reduceLeft: linear reduceLeft w/ random data | 50 trials
	2.7916 milliseconds | treduce: parallel reduce w/ random data | 50 trials
```

closes #35 